### PR TITLE
Fix Acknowledgments

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,4 +133,4 @@ This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md
 
 ## Acknowledgments
 
-* md_5 and his team for designing the Plugin Messaging Channels.
+* Dinnerbone for designing the Plugin Messaging Channels.


### PR DESCRIPTION
neither md_5 nor anybody at spigot had anything to do with plugin messaging channels. They have been designed and implemented by Dinnerbone for both the client (minecraft) and the server (bukkit).

See https://dinnerbone.com/blog/2012/01/13/minecraft-plugin-channels-messaging/ 
and https://github.com/Bukkit/Bukkit/commit/55cc8722c8260939f5f0ea57385e4edd8b70ed0c