### PR TITLE
Factories instead of constructors, additional protected fields

### DIFF
--- a/commy-bungee/src/main/java/com/github/expdev07/commy/bungee/BungeeCommy.java
+++ b/commy-bungee/src/main/java/com/github/expdev07/commy/bungee/BungeeCommy.java
@@ -18,9 +18,8 @@ public class BungeeCommy extends Commy<ServerInfo> {
 
     private Plugin plugin;
 
-    public BungeeCommy(Plugin plugin) {
+    protected BungeeCommy(Plugin plugin) {
         this.plugin = plugin;
-        setup();
     }
 
     @Override
@@ -56,7 +55,7 @@ public class BungeeCommy extends Commy<ServerInfo> {
         private Plugin plugin;
         private BungeeCommy commy;
 
-        public MessageListener(Plugin plugin, BungeeCommy commy) {
+        MessageListener(Plugin plugin, BungeeCommy commy) {
             this.plugin = plugin;
             this.commy = commy;
         }

--- a/commy-bungee/src/main/java/com/github/expdev07/commy/bungee/BungeeCommyFactory.java
+++ b/commy-bungee/src/main/java/com/github/expdev07/commy/bungee/BungeeCommyFactory.java
@@ -1,0 +1,16 @@
+package com.github.expdev07.commy.bungee;
+
+import com.github.expdev07.commy.core.Commy;
+import net.md_5.bungee.api.config.ServerInfo;
+import net.md_5.bungee.api.plugin.Plugin;
+
+public class BungeeCommyFactory {
+
+    public static Commy<ServerInfo> createCommy(Plugin plugin) {
+        BungeeCommy commy = new BungeeCommy(plugin);
+
+        commy.setup();
+
+        return commy;
+    }
+}

--- a/commy-core/src/main/java/com/github/expdev07/commy/core/Commy.java
+++ b/commy-core/src/main/java/com/github/expdev07/commy/core/Commy.java
@@ -68,7 +68,7 @@ public abstract class Commy<T> {
     /**
      * Setup appropriate stuff
      */
-    public abstract void setup();
+    protected abstract void setup();
 
     /**
      * Gets a connection with the target

--- a/commy-spigot/src/main/java/com/github/expdev07/commy/spigot/SpigotCommy.java
+++ b/commy-spigot/src/main/java/com/github/expdev07/commy/spigot/SpigotCommy.java
@@ -17,9 +17,8 @@ public class SpigotCommy extends Commy<Player> {
 
     private JavaPlugin plugin;
 
-    public SpigotCommy(JavaPlugin plugin) {
+    protected SpigotCommy(JavaPlugin plugin) {
         this.plugin = plugin;
-        setup();
     }
 
     @Override
@@ -51,7 +50,7 @@ public class SpigotCommy extends Commy<Player> {
 
         private SpigotCommy commy;
 
-        public MessageListener(SpigotCommy commy) {
+        MessageListener(SpigotCommy commy) {
             this.commy = commy;
         }
 

--- a/commy-spigot/src/main/java/com/github/expdev07/commy/spigot/SpigotCommyFactory.java
+++ b/commy-spigot/src/main/java/com/github/expdev07/commy/spigot/SpigotCommyFactory.java
@@ -1,0 +1,17 @@
+package com.github.expdev07.commy.spigot;
+
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Copyright (c) 2013-2018 Tyler Grissom
+ */
+public class SpigotCommyFactory {
+
+    public static SpigotCommy createCommy(JavaPlugin plugin) {
+        SpigotCommy commy = new SpigotCommy(plugin);
+
+        commy.setup();
+
+        return commy;
+    }
+}

--- a/commy-spigot/src/main/java/com/github/expdev07/commy/spigot/SpigotCommyFactory.java
+++ b/commy-spigot/src/main/java/com/github/expdev07/commy/spigot/SpigotCommyFactory.java
@@ -1,13 +1,12 @@
 package com.github.expdev07.commy.spigot;
 
+import com.github.expdev07.commy.core.Commy;
+import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 
-/**
- * Copyright (c) 2013-2018 Tyler Grissom
- */
 public class SpigotCommyFactory {
 
-    public static SpigotCommy createCommy(JavaPlugin plugin) {
+    public static Commy<Player> createCommy(JavaPlugin plugin) {
         SpigotCommy commy = new SpigotCommy(plugin);
 
         commy.setup();

--- a/spigot-plugin/src/main/java/com/github/expdev07/commy/spigotplugin/SpigotPlugin.java
+++ b/spigot-plugin/src/main/java/com/github/expdev07/commy/spigotplugin/SpigotPlugin.java
@@ -5,6 +5,7 @@ import com.github.expdev07.commy.core.Connection;
 import com.github.expdev07.commy.core.handler.AbstractMessageHandler;
 import com.github.expdev07.commy.core.handler.StringMessageHandler;
 import com.github.expdev07.commy.spigot.SpigotCommy;
+import com.github.expdev07.commy.spigot.SpigotCommyFactory;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -27,8 +28,8 @@ public class SpigotPlugin extends JavaPlugin {
     public void onEnable() {
         logger = Bukkit.getLogger();
 
-        // Initialize commy, calling setup will start the engines
-        this.commy = new SpigotCommy(this);
+        // Initialize commy, will self setup
+        this.commy = SpigotCommyFactory.createCommy(this);
 
         // Adding handlers, you can add as many as you want
         // The first parameter here is the "pipe" the handler will handle messages for


### PR DESCRIPTION
As per the recommendation of many Spigot developers, I protected the methods and constructors in favor of `SpigotCommyFactory#createCommy`